### PR TITLE
fix twitter link

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
       <h3>Community</h3>
       <ul class="foot-list">
         <li>
-          <a href="twitter.com/animadio" rel="noreferrer noopener" target="_blank">Twitter</a>
+          <a href="https://twitter.com/animadio" rel="noreferrer noopener" target="_blank">Twitter</a>
         </li>
         <li>
           <a href="https://join.slack.com/t/animadio/shared_invite/enQtNTY1NTc5NzgyNDA3LTI2YWIxM2ZkMGM5ODBkNjNjZmI5ZGVlNTM1ZWEwMWI5ZDJjNzViYjNmNWE2MjllMTc3MDhlMzYzZDYzNTkxNjU" rel="noreferrer noopener" target="_blank">Slack</a>


### PR DESCRIPTION
I fixed a twitter link that was missing the protocol. The link is under "Community" in the footer of the index page.